### PR TITLE
Fix incorrect json

### DIFF
--- a/autogame/web.py
+++ b/autogame/web.py
@@ -72,9 +72,10 @@ class GetApiSeedHandler(tornado.web.RequestHandler):
 
         i = 1
         for entry in self.db_seed_matches:
-            api_dict[i] = entry[0]
+            api_dict[str(i)] = entry[0]
             i += 1
 
+        # TODO: api.html is not in the repo
         self.render("api.html",text=api_dict)
 
 


### PR DESCRIPTION
Since api.html (not in the repo, so not sure this fixes) expects a dict, the keys have to be strings, not integers.

the api currently sends
{ 0: "blabla", 1: "blabla" }

that is not valid json.
either it's a list and therefore
["blabla","blabla"]
(would be the right structure for that api call)

either it's a dict, and the keys have to be enclosed by double quotes, or it's not valid json.
{ "0": "blabla", "1": "blabla" }

Best way for API would be to directly return a json encoded answer, no need for html view